### PR TITLE
toggle: add jump-to-sidebar command

### DIFF
--- a/agent-shell-hq-toggle.el
+++ b/agent-shell-hq-toggle.el
@@ -519,6 +519,16 @@ On a project header: toggle collapse."
 ;;;; Entry point
 
 ;;;###autoload
+(defun agent-shell-hq-toggle-jump-to-sidebar ()
+  "Jump to the sidebar buffer if it exists, otherwise open the toggle workspace."
+  (interactive)
+  (if (get-buffer agent-shell-hq-toggle--sidebar-name)
+      (if (get-buffer-window agent-shell-hq-toggle--sidebar-name)
+          (select-window (get-buffer-window agent-shell-hq-toggle--sidebar-name))
+        (agent-shell-hq-toggle))
+    (agent-shell-hq-toggle)))
+
+;;;###autoload
 (defun agent-shell-hq-toggle ()
   "Toggle the agent-shell HQ workspace.
 


### PR DESCRIPTION
'agent-shell-hq-toggle-jump-to-sidebar' jumps to the sidebar window if it exists, otherwise opens the toggle workspace.

Suggested binding:
  (global-set-key (kbd "C-c a s") #'agent-shell-hq-toggle-jump-to-sidebar)