### PR TITLE
toggle: ensure persp-mode is active before querying perspective

### DIFF
--- a/agent-shell-hq-toggle.el
+++ b/agent-shell-hq-toggle.el
@@ -537,6 +537,8 @@ Sidebar keys:
   s      new agent-shell in current project
   q      quit (return to previous perspective)"
   (interactive)
+  (unless (bound-and-true-p persp-mode)
+    (persp-mode 1))
   (if (string= (safe-persp-name (get-current-persp))
                agent-shell-hq-toggle--persp-name)
       (let ((prev agent-shell-hq-toggle--prev-persp))


### PR DESCRIPTION
When `agent-shell-hq-toggle` is called, it queries `(get-current-persp)` to determine the current perspective name. If `persp-mode` is loaded but not yet enabled, `(get-current-persp)` attempts to access an uninitialized hash table and signals `Wrong type argument: hash-table-p, nil`.

This ensures `persp-mode` is active before querying or switching perspectives.