### PR TITLE
peek+toggle: add blocked state pause icon for pending user input

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ All public symbols use the `agent-shell-hq-` prefix; internal helpers use `agent
 
 **Toggle workspace** uses a named perspective (`*agent-shell*`). Toggle-off switches back to the recorded previous perspective — the workspace perspective is not destroyed.
 
-**SVG icons** are loaded from `icons/` at package load time and cached as Emacs `image` objects keyed by state (`idle`, `busy`, `dead`). Icons are regenerated on state change, not on a timer. Buffer state is derived from `shell-maker-busy`.
+**SVG icons** are loaded from `icons/` at package load time and cached as Emacs `image` objects keyed by state (`idle`, `busy`, `blocked`, `dead`). Icons are regenerated on state change, not on a timer. Buffer state is derived from `agent-shell-status` / `shell-maker-busy`.
 
 **Buffer grouping** — `agent-shell-hq-peek--grouped-buffers` returns `(root project-name buffers)` triples sorted alphabetically by project name, with buffers within each group also sorted alphabetically by buffer name.
 
@@ -52,7 +52,7 @@ All public symbols use the `agent-shell-hq-` prefix; internal helpers use `agent
 
 - **Adding a new module**: follow the `agent-shell-hq-<module>.el` naming pattern; `require` it from `agent-shell-hq-toggle.el` or whichever consumer needs it.
 - **Changing buffer grouping logic**: the shared function is `agent-shell-hq-peek--grouped-buffers` in `agent-shell-hq-peek.el`; both peek and toggle call it.
-- **Changing SVG icons**: icons live in `icons/` as `idle.svg`, `busy.svg`, `dead.svg`. The cache is populated lazily on first use. In TUI Emacs (no image support), `agent-shell-hq-fallback-icons` provides Unicode character + face fallbacks (default: ✓/◔/✗ with `success`/`warning`/`error` faces via `font-lock-face`, matching agent-shell's own status icon style).
+- **Changing SVG icons**: icons live in `icons/` as `idle.svg`, `busy.svg`, `blocked.svg`, `dead.svg`. The cache is populated lazily on first use. In TUI Emacs (no image support), `agent-shell-hq-fallback-icons` provides Unicode character + face fallbacks (default: ✓/◔/⯄/✗ with `success`/`warning`/`error`/`error` faces via `font-lock-face`, matching agent-shell's own status icon style).
 - **Changing the titling model/CLI**: update the `agent-shell-hq-label-command` default in `agent-shell-hq-label.el`.
 - **Keymap changes**: peek keys are in `agent-shell-hq-peek-map`; toggle keys are in `agent-shell-hq-toggle-map`. The transient help menu (`agent-shell-hq-toggle-help`) must be kept in sync with the keymap manually.
 - **Testing**: load the file in a running Emacs with `agent-shell` active and exercise the entry points interactively. There is no automated test suite.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ An add-on to [agent-shell](https://github.com/xenodium/agent-shell) that provide
 
 ![agent-shell-hq toggle demo](assets/toggle-demo.gif)
 
-`M-x agent-shell-hq-toggle` opens a dedicated workspace with a sidebar listing all your agent-shell buffers grouped by project. Each buffer shows a live status icon (idle/busy/dead). Navigating the sidebar immediately previews the selected buffer in the main window.
+`M-x agent-shell-hq-toggle` opens a dedicated workspace with a sidebar listing all your agent-shell buffers grouped by project. Each buffer shows a live status icon (idle/busy/blocked/dead). Navigating the sidebar immediately previews the selected buffer in the main window.
 
 Calling `agent-shell-hq-toggle` again returns you to your previous workspace.
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -191,7 +191,7 @@ No timer. Icons are loaded lazily on first use and cached. State is checked per-
 
 ### 3.3 Icon cache
 
-Icons are cached as `image` objects keyed by `state` — three entries total (`idle`, `busy`, `dead`). Cache is populated lazily on first call to `agent-shell-hq-peek--svg-icon`.
+Icons are cached as `image` objects keyed by `state` — four entries total (`idle`, `busy`, `blocked`, `dead`). Cache is populated lazily on first call to `agent-shell-hq-peek--svg-icon`.
 
 Colors are baked into the SVG files on disk (not derived dynamically from theme faces).
 
@@ -235,6 +235,6 @@ agent-shell-hq/
 ├── agent-shell-hq-peek.el    ; posframe switcher, shared buffer grouping
 ├── agent-shell-hq-toggle.el  ; sidebar workspace
 ├── agent-shell-hq-label.el   ; async session labelling via Anthropic REST API
-├── icons/                    ; idle.svg, busy.svg, dead.svg
+├── icons/                    ; idle.svg, busy.svg, blocked.svg, dead.svg
 └── SPEC.md                   ; this file
 ```

--- a/agent-shell-hq-peek.el
+++ b/agent-shell-hq-peek.el
@@ -128,6 +128,10 @@ Uses the existing viewport buffer when one already exists, so its mode
     (busy . "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"20\" height=\"20\" viewBox=\"0 0 20 20\">
   <polygon points=\"10,2 18.5,17.5 1.5,17.5\" fill=\"#C9922A\"/>
 </svg>")
+    (blocked . "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"20\" height=\"20\" viewBox=\"0 0 20 20\">
+  <polygon points=\"18.5,6.5 13.5,1.5 6.5,1.5 1.5,6.5 1.5,13.5 6.5,18.5 13.5,18.5 18.5,13.5\" fill=\"#D32F2F\"/>
+  <polygon points=\"16.5,7.0 13.0,3.5 7.0,3.5 3.5,7.0 3.5,13.0 7.0,16.5 13.0,16.5 16.5,13.0\" fill=\"none\" stroke=\"white\" stroke-width=\"1.2\"/>
+</svg>")
     (dead . "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"20\" height=\"20\" viewBox=\"0 0 20 20\">
   <circle cx=\"10\" cy=\"10\" r=\"8.5\" fill=\"#C0392B\"/>
   <line x1=\"6.5\" y1=\"6.5\" x2=\"13.5\" y2=\"13.5\" stroke=\"white\" stroke-width=\"2.5\" stroke-linecap=\"round\"/>
@@ -135,15 +139,26 @@ Uses the existing viewport buffer when one already exists, so its mode
 </svg>"))
   "Inline SVG strings for each buffer state.")
 
+(defun agent-shell-hq-peek--svg-icon (state)
+  "Return the cached SVG image for STATE (`busy', `blocked', `idle', or `dead')."
+  (unless agent-shell-hq-peek--icon-cache
+    (setq agent-shell-hq-peek--icon-cache
+          (mapcar (lambda (pair)
+                    (cons (car pair)
+                          (create-image (cdr pair) 'svg t :ascent 'center)))
+                  agent-shell-hq-peek--icon-svgs)))
+  (alist-get state agent-shell-hq-peek--icon-cache))
+
 (defcustom agent-shell-hq-fallback-icons
   '((idle . ("✓" . success))
     (busy . ("◔" . warning))
+    (blocked . ("⯄" . error))
     (dead . ("✗" . error)))
   "Fallback Unicode characters for TUI Emacs.
 Each entry is (STATE . (CHAR . FACE)), used when image display is
 unavailable (e.g. terminal Emacs).  Uses `font-lock-face' so the
 color survives outer `face' text properties in the render code."
-  :type '(alist :key-type (choice (const idle) (const busy) (const dead))
+  :type '(alist :key-type (choice (const idle) (const busy) (const blocked) (const dead))
                 :value-type (cons string face))
   :group 'agent-shell-hq-peek)
 
@@ -152,22 +167,23 @@ color survives outer `face' text properties in the render code."
 In GUI Emacs with SVG support, this is a space with a `display' SVG
 image property.  Otherwise, this is a Unicode character with a face."
   (if (and (display-graphic-p) (image-type-available-p 'svg))
-      (progn
-        (unless agent-shell-hq-peek--icon-cache
-          (setq agent-shell-hq-peek--icon-cache
-                (mapcar (lambda (pair)
-                          (cons (car pair)
-                                (create-image (cdr pair) 'svg t :ascent 'center)))
-                        agent-shell-hq-peek--icon-svgs)))
-        (propertize " " 'display (alist-get state agent-shell-hq-peek--icon-cache)))
+      (propertize " " 'display (agent-shell-hq-peek--svg-icon state))
     (let ((fallback (alist-get state agent-shell-hq-fallback-icons)))
-      (propertize (car fallback) 'face (cdr fallback)))))
+      (propertize (car fallback) 'face (cdr fallback) 'font-lock-face (cdr fallback)))))
 
 (defun agent-shell-hq-peek--buffer-state (buf)
-  "Return `busy', `idle', or `dead' for BUF."
+  "Return `busy', `blocked', `idle', or `dead' for BUF."
   (if (buffer-live-p buf)
       (with-current-buffer buf
-        (if (shell-maker-busy) 'busy 'idle))
+        (cond
+         ((and (fboundp 'agent-shell-status)
+               (eq (agent-shell-status :shell-buffer buf) 'blocked))
+          'blocked)
+         ((and (fboundp 'agent-shell--permission-pending-p)
+               (agent-shell--permission-pending-p :shell-buffer buf))
+          'blocked)
+         ((shell-maker-busy) 'busy)
+         (t 'idle)))
     'dead))
 
 ;;;; Buffer grouping

--- a/icons/blocked.svg
+++ b/icons/blocked.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20">
+  <polygon points="18.5,6.5 13.5,1.5 6.5,1.5 1.5,6.5 1.5,13.5 6.5,18.5 13.5,18.5 18.5,13.5" fill="#D32F2F"/>
+  <polygon points="16.5,7.0 13.0,3.5 7.0,3.5 3.5,7.0 3.5,13.0 7.0,16.5 13.0,16.5 16.5,13.0" fill="none" stroke="white" stroke-width="1.2"/>
+</svg>


### PR DESCRIPTION
Adds support for displaying a distinct amber pause icon when an `agent-shell` session is blocked waiting for user input/permission response:

- Checks `agent-shell-status` / `agent-shell--permission-pending-p` to report the `blocked` state.
- Adds an SVG pause icon in `icons/blocked.svg` and inlined in `agent-shell-hq-peek--icon-svgs`.
- Updates `agent-shell-hq-peek--buffer-state` and icon caches to support `blocked`.