### PR TITLE
peek+toggle: align state icons with agent-shell

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,7 @@ All public symbols use the `agent-shell-hq-` prefix; internal helpers use `agent
 
 - **Adding a new module**: follow the `agent-shell-hq-<module>.el` naming pattern; `require` it from `agent-shell-hq-toggle.el` or whichever consumer needs it.
 - **Changing buffer grouping logic**: the shared function is `agent-shell-hq-peek--grouped-buffers` in `agent-shell-hq-peek.el`; both peek and toggle call it.
-- **Changing SVG icons**: icons live in `icons/` as `idle.svg`, `busy.svg`, `blocked.svg`, `dead.svg`. The cache is populated lazily on first use. In TUI Emacs (no image support), `agent-shell-hq-fallback-icons` provides Unicode character + face fallbacks (default: ✓/◔/⯄/✗ with `success`/`warning`/`error`/`error` faces via `font-lock-face`, matching agent-shell's own status icon style).
+- **Changing SVG icons**: icons live in `icons/` as `idle.svg`, `busy.svg`, `blocked.svg`, `dead.svg`. The cache is populated lazily on first use. In TUI Emacs (no image support), `agent-shell-hq-fallback-icons` provides Unicode character + face fallbacks (default: ✓/◔/⚠/✗ with `success`/`warning`/`error`/`error` faces via `font-lock-face`, matching agent-shell's own status icon style).
 - **Changing the titling model/CLI**: update the `agent-shell-hq-label-command` default in `agent-shell-hq-label.el`.
 - **Keymap changes**: peek keys are in `agent-shell-hq-peek-map`; toggle keys are in `agent-shell-hq-toggle-map`. The transient help menu (`agent-shell-hq-toggle-help`) must be kept in sync with the keymap manually.
 - **Testing**: load the file in a running Emacs with `agent-shell` active and exercise the entry points interactively. There is no automated test suite.

--- a/agent-shell-hq-peek.el
+++ b/agent-shell-hq-peek.el
@@ -126,11 +126,15 @@ Uses the existing viewport buffer when one already exists, so its mode
             stroke-linecap=\"round\" stroke-linejoin=\"round\"/>
 </svg>")
     (busy . "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"20\" height=\"20\" viewBox=\"0 0 20 20\">
-  <polygon points=\"10,2 18.5,17.5 1.5,17.5\" fill=\"#C9922A\"/>
+  <circle cx=\"10\" cy=\"10\" r=\"8.5\" fill=\"#C9922A\"/>
+  <circle cx=\"10\" cy=\"10\" r=\"6\" fill=\"none\" stroke=\"white\" stroke-width=\"1.2\"/>
+  <line x1=\"10\" y1=\"10\" x2=\"10\" y2=\"5.5\" stroke=\"white\" stroke-width=\"1.8\" stroke-linecap=\"round\"/>
+  <line x1=\"10\" y1=\"10\" x2=\"13.5\" y2=\"10\" stroke=\"white\" stroke-width=\"1.8\" stroke-linecap=\"round\"/>
 </svg>")
     (blocked . "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"20\" height=\"20\" viewBox=\"0 0 20 20\">
-  <polygon points=\"18.5,6.5 13.5,1.5 6.5,1.5 1.5,6.5 1.5,13.5 6.5,18.5 13.5,18.5 18.5,13.5\" fill=\"#D32F2F\"/>
-  <polygon points=\"16.5,7.0 13.0,3.5 7.0,3.5 3.5,7.0 3.5,13.0 7.0,16.5 13.0,16.5 16.5,13.0\" fill=\"none\" stroke=\"white\" stroke-width=\"1.2\"/>
+  <polygon points=\"10,2 18.5,17.5 1.5,17.5\" fill=\"#C0392B\"/>
+  <line x1=\"10\" y1=\"7\" x2=\"10\" y2=\"12.5\" stroke=\"white\" stroke-width=\"1.8\" stroke-linecap=\"round\"/>
+  <circle cx=\"10\" cy=\"14.5\" r=\"1\" fill=\"white\"/>
 </svg>")
     (dead . "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"20\" height=\"20\" viewBox=\"0 0 20 20\">
   <circle cx=\"10\" cy=\"10\" r=\"8.5\" fill=\"#C0392B\"/>
@@ -152,7 +156,7 @@ Uses the existing viewport buffer when one already exists, so its mode
 (defcustom agent-shell-hq-fallback-icons
   '((idle . ("✓" . success))
     (busy . ("◔" . warning))
-    (blocked . ("⯄" . error))
+    (blocked . ("⚠" . error))
     (dead . ("✗" . error)))
   "Fallback Unicode characters for TUI Emacs.
 Each entry is (STATE . (CHAR . FACE)), used when image display is

--- a/icons/blocked.svg
+++ b/icons/blocked.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20">
-  <polygon points="18.5,6.5 13.5,1.5 6.5,1.5 1.5,6.5 1.5,13.5 6.5,18.5 13.5,18.5 18.5,13.5" fill="#D32F2F"/>
-  <polygon points="16.5,7.0 13.0,3.5 7.0,3.5 3.5,7.0 3.5,13.0 7.0,16.5 13.0,16.5 16.5,13.0" fill="none" stroke="white" stroke-width="1.2"/>
+  <polygon points="10,2 18.5,17.5 1.5,17.5" fill="#C0392B"/>
+  <line x1="10" y1="7" x2="10" y2="12.5" stroke="white" stroke-width="1.8" stroke-linecap="round"/>
+  <circle cx="10" cy="14.5" r="1" fill="white"/>
 </svg>

--- a/icons/busy.svg
+++ b/icons/busy.svg
@@ -1,3 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20">
-  <polygon points="10,2 18.5,17.5 1.5,17.5" fill="#C9922A"/>
+  <circle cx="10" cy="10" r="8.5" fill="#C9922A"/>
+  <circle cx="10" cy="10" r="6" fill="none" stroke="white" stroke-width="1.2"/>
+  <line x1="10" y1="10" x2="10" y2="5.5" stroke="white" stroke-width="1.8" stroke-linecap="round"/>
+  <line x1="10" y1="10" x2="13.5" y2="10" stroke="white" stroke-width="1.8" stroke-linecap="round"/>
 </svg>


### PR DESCRIPTION
Problems

- TUI fallback character for "Blocked" is not widely supported: on macOS, common Nerd Fonts like Liga SFMono, FiraCode, and Cascadia Code NF all render it as a missing-character box, only JetBrains Mono contains this glyph. .
- Icons inconsistent with agent-shell — agent-shell uses ✓/◔/⚠/✗ for idle/busy/awaiting-permission/error, but agent-shell-hq's SVG and TUI icons diverged from this set.

Changes

- Idle: unchanged.
- Busy: SVG changed from an amber triangle to an amber clock face (solid circle + white inner ring + white hands at 12 and 3), matching the ◔ TUI glyph. TUI fallback unchanged.
- Blocked: SVG changed from a red octagon to a red warning triangle (solid triangle + white exclamation mark), matching the ⚠ TUI glyph. The triangle uses the same red (#C0392B) as the dead icon, since both are error-class states. TUI fallback changed from ⯄ to ⚠.
- Dead: unchanged

This makes GUI and TUI icons visually consistent and aligns the full state icon set (✓/◔/⚠/✗) with agent-shell's own.